### PR TITLE
Update docker and scan to use official Docker actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,26 +37,26 @@ jobs:
    - name: Checkout code
      uses: actions/checkout@v2
 
-   - name: Set up Docker
-     uses: docker-practice/actions-setup-docker@v1
+   - name: Log into Docker Hub
+     uses: docker/login-action@v2
      with:
-      docker_version: '20.10.7'
+      username: ${{ secrets.DOCKER_USER }}
+      password: ${{ secrets.DOCKER_PAT }}
+
+   - name: Set up Docker
+     uses: docker/setup-buildx-action@v3
 
    - name: Build Docker Image
-     run: docker build -f Dockerfile -t myapp:latest .
+     uses: docker/build-push-action@v4
+     with:
+       context: .
+       load: true
+       tags: myapp:latest
+       sbom: false
+       provenance: false
 
    - name: Docker Scout Scan
-     run: |
-       curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh -o install-scout.sh
-       sh install-scout.sh
-       docker scout quickview
-       docker scout cves
-
-
-
-
-
-
-   
-
-   
+     uses: docker/scout-action@v1
+     with:
+       command: quickview,cves
+       image: myapp:latest


### PR DESCRIPTION
This pull requests moves the `docker build` and `docker scout` steps of the GitHub Action workflow to use official Docker GitHub Actions:

* `docker/login-action` to log into Docker Hub as required for Docker Scout
* `docker/setup-buildx-action` to configure the Docker build environment
* `docker/build-push-action` to build the image and load it into the local daemon
* and finally `docker/scout-action` to run Docker Scout commands on the built image

Thanks for creating this awesome demo and video. I enjoyed watching and following at https://www.youtube.com/watch?v=gLJdrXPn0ns.